### PR TITLE
Include X-Rate headers only for successfully requests

### DIFF
--- a/src/Models/Meta.php
+++ b/src/Models/Meta.php
@@ -20,7 +20,9 @@ class Meta extends BaseModel
     {
         $this->code = (int)$data->code;
 
-        if ($this->code === 200) {
+        if ($this->code === 200 ||
+            $this->code === 429
+        ) {
             $this->limit = (int)$data->headers['X-Rate-Limit-Limit'];
             $this->remaining = (int)$data->headers['X-Rate-Limit-Remaining'];
             $this->reset = $this->setDate($data);

--- a/src/Models/Meta.php
+++ b/src/Models/Meta.php
@@ -19,9 +19,12 @@ class Meta extends BaseModel
     public function __construct($data)
     {
         $this->code = (int)$data->code;
-        $this->limit = (int)$data->headers['X-Rate-Limit-Limit'];
-        $this->remaining = (int)$data->headers['X-Rate-Limit-Remaining'];
-        $this->reset = $this->setDate($data);
+
+        if ($this->code === 200) {
+            $this->limit = (int)$data->headers['X-Rate-Limit-Limit'];
+            $this->remaining = (int)$data->headers['X-Rate-Limit-Remaining'];
+            $this->reset = $this->setDate($data);
+        }
     }
 
     /**


### PR DESCRIPTION
Genderize does not return the X-Rate headers for unsuccessful requests, eg when the rate limit has been exceeded, missing or incorrect params are supplied. When such an event takes place an error occurs as the `$data->headers[X-Rate-*]` array key is not set.